### PR TITLE
Add missing annotation @Transactional

### DIFF
--- a/src/main/java/pe/edu/upc/demo/model/Sede.java
+++ b/src/main/java/pe/edu/upc/demo/model/Sede.java
@@ -11,9 +11,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
+import org.springframework.transaction.annotation.Transactional;
 
 @Entity
 @Table(name = "sedes")
+@Transactional
 public class Sede {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
It is better to add annotation @Transactional in this class, because it is much easier to detect errors and can roll back data access operations.